### PR TITLE
Test app_utils and code formatters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 venv
+.venv/
+.coverage
+
 packages
 
 *.swp
@@ -10,3 +13,4 @@ __pycache__
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,7 @@ repos:
        rev: 21.9b0
        hooks:
          - id: black
+     - repo: https://github.com/pycqa/isort
+       rev: 5.12.0
+       hooks:
+         - id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+     - repo: https://github.com/psf/black
+       rev: 21.9b0
+       hooks:
+         - id: black

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,9 @@ boto3 = "*"
 [dev-packages]
 pytest = "*"
 pytest-cov = "*"
+black = "*"
+flake8 = "*"
+isort = "*"
 
 [requires]
 python_version = "3.11"

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ pytest-cov = "*"
 black = "*"
 flake8 = "*"
 isort = "*"
+pre-commit = "*"
 
 [requires]
 python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b6a2fef24c1518c3b31fba54c207b1e678325c0b5f5e537d489b70b00ef7d51a"
+            "sha256": "fdd3d16354d9867821a5267b651a7320aaadeccbd7d12f241ff64f2990691003"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,20 +18,20 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:72eb73d90448632d7388644388be6977293ccb8fbfefd5fd39d7e75ff2d48f8a",
-                "sha256:73d4f22b57a725f0e8a6e0c4b2d16336c128e39f3189c24f9e513daa7c14936b"
+                "sha256:234a475fe56b65e99b4f5cfff50adaac6b23d39558d6b55137bbf1e50dd0ef08",
+                "sha256:90c8cddc4a08c8040057ad44c7468ff82fea9fe8b6517db5ff01a9b2900299cc"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.35"
+            "version": "==1.35.38"
         },
         "botocore": {
             "hashes": [
-                "sha256:44b843e310b6338c3086908928709c7a303a2bb0326ea3c93ece5ac5afafb6c8",
-                "sha256:899d303046391caa1d05093a673e52d02185b37bc64bd78771ad6752167a25ab"
+                "sha256:2eb17d32fa2d3bb5d475132a83564d28e3acc2161534f24b75a54418a1d51359",
+                "sha256:55d9305c44e5ba29476df456120fa4fb919f03f066afa82f2ae400485e7465f4"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.35"
+            "version": "==1.35.38"
         },
         "certifi": {
             "hashes": [
@@ -43,99 +43,114 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027",
-                "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087",
-                "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786",
-                "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8",
-                "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09",
-                "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185",
-                "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574",
-                "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e",
-                "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519",
-                "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898",
-                "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269",
-                "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3",
-                "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f",
-                "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6",
-                "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8",
-                "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a",
-                "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73",
-                "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc",
-                "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714",
-                "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2",
-                "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc",
-                "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce",
-                "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d",
-                "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e",
-                "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6",
-                "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269",
-                "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
-                "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d",
-                "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a",
-                "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4",
-                "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77",
-                "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d",
-                "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0",
-                "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed",
-                "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068",
-                "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac",
-                "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25",
-                "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8",
-                "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab",
-                "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26",
-                "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2",
-                "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db",
-                "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f",
-                "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5",
-                "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99",
-                "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c",
-                "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d",
-                "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811",
-                "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa",
-                "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a",
-                "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03",
-                "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b",
-                "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04",
-                "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c",
-                "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001",
-                "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458",
-                "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389",
-                "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99",
-                "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985",
-                "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537",
-                "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238",
-                "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f",
-                "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d",
-                "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796",
-                "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a",
-                "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143",
-                "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8",
-                "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c",
-                "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5",
-                "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5",
-                "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711",
-                "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4",
-                "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6",
-                "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c",
-                "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7",
-                "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4",
-                "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b",
-                "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae",
-                "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12",
-                "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c",
-                "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae",
-                "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8",
-                "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887",
-                "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b",
-                "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4",
-                "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f",
-                "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
-                "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33",
-                "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519",
-                "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
+                "sha256:0099d79bdfcf5c1f0c2c72f91516702ebf8b0b8ddd8905f97a8aecf49712c621",
+                "sha256:0713f3adb9d03d49d365b70b84775d0a0d18e4ab08d12bc46baa6132ba78aaf6",
+                "sha256:07afec21bbbbf8a5cc3651aa96b980afe2526e7f048fdfb7f1014d84acc8b6d8",
+                "sha256:0b309d1747110feb25d7ed6b01afdec269c647d382c857ef4663bbe6ad95a912",
+                "sha256:0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c",
+                "sha256:0de7b687289d3c1b3e8660d0741874abe7888100efe14bd0f9fd7141bcbda92b",
+                "sha256:1110e22af8ca26b90bd6364fe4c763329b0ebf1ee213ba32b68c73de5752323d",
+                "sha256:130272c698667a982a5d0e626851ceff662565379baf0ff2cc58067b81d4f11d",
+                "sha256:136815f06a3ae311fae551c3df1f998a1ebd01ddd424aa5603a4336997629e95",
+                "sha256:14215b71a762336254351b00ec720a8e85cada43b987da5a042e4ce3e82bd68e",
+                "sha256:1db4e7fefefd0f548d73e2e2e041f9df5c59e178b4c72fbac4cc6f535cfb1565",
+                "sha256:1ffd9493de4c922f2a38c2bf62b831dcec90ac673ed1ca182fe11b4d8e9f2a64",
+                "sha256:2006769bd1640bdf4d5641c69a3d63b71b81445473cac5ded39740a226fa88ab",
+                "sha256:20587d20f557fe189b7947d8e7ec5afa110ccf72a3128d61a2a387c3313f46be",
+                "sha256:223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e",
+                "sha256:27623ba66c183eca01bf9ff833875b459cad267aeeb044477fedac35e19ba907",
+                "sha256:285e96d9d53422efc0d7a17c60e59f37fbf3dfa942073f666db4ac71e8d726d0",
+                "sha256:2de62e8801ddfff069cd5c504ce3bc9672b23266597d4e4f50eda28846c322f2",
+                "sha256:2f6c34da58ea9c1a9515621f4d9ac379871a8f21168ba1b5e09d74250de5ad62",
+                "sha256:309a7de0a0ff3040acaebb35ec45d18db4b28232f21998851cfa709eeff49d62",
+                "sha256:35c404d74c2926d0287fbd63ed5d27eb911eb9e4a3bb2c6d294f3cfd4a9e0c23",
+                "sha256:3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc",
+                "sha256:3d59d125ffbd6d552765510e3f31ed75ebac2c7470c7274195b9161a32350284",
+                "sha256:40d3ff7fc90b98c637bda91c89d51264a3dcf210cade3a2c6f838c7268d7a4ca",
+                "sha256:425c5f215d0eecee9a56cdb703203dda90423247421bf0d67125add85d0c4455",
+                "sha256:43193c5cda5d612f247172016c4bb71251c784d7a4d9314677186a838ad34858",
+                "sha256:44aeb140295a2f0659e113b31cfe92c9061622cadbc9e2a2f7b8ef6b1e29ef4b",
+                "sha256:47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594",
+                "sha256:4796efc4faf6b53a18e3d46343535caed491776a22af773f366534056c4e1fbc",
+                "sha256:4a51b48f42d9358460b78725283f04bddaf44a9358197b889657deba38f329db",
+                "sha256:4b67fdab07fdd3c10bb21edab3cbfe8cf5696f453afce75d815d9d7223fbe88b",
+                "sha256:4ec9dd88a5b71abfc74e9df5ebe7921c35cbb3b641181a531ca65cdb5e8e4dea",
+                "sha256:4f9fc98dad6c2eaa32fc3af1417d95b5e3d08aff968df0cd320066def971f9a6",
+                "sha256:54b6a92d009cbe2fb11054ba694bc9e284dad30a26757b1e372a1fdddaf21920",
+                "sha256:55f56e2ebd4e3bc50442fbc0888c9d8c94e4e06a933804e2af3e89e2f9c1c749",
+                "sha256:5726cf76c982532c1863fb64d8c6dd0e4c90b6ece9feb06c9f202417a31f7dd7",
+                "sha256:5d447056e2ca60382d460a604b6302d8db69476fd2015c81e7c35417cfabe4cd",
+                "sha256:5ed2e36c3e9b4f21dd9422f6893dec0abf2cca553af509b10cd630f878d3eb99",
+                "sha256:5ff2ed8194587faf56555927b3aa10e6fb69d931e33953943bc4f837dfee2242",
+                "sha256:62f60aebecfc7f4b82e3f639a7d1433a20ec32824db2199a11ad4f5e146ef5ee",
+                "sha256:63bc5c4ae26e4bc6be6469943b8253c0fd4e4186c43ad46e713ea61a0ba49129",
+                "sha256:6b40e8d38afe634559e398cc32b1472f376a4099c75fe6299ae607e404c033b2",
+                "sha256:6b493a043635eb376e50eedf7818f2f322eabbaa974e948bd8bdd29eb7ef2a51",
+                "sha256:6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee",
+                "sha256:6fd30dc99682dc2c603c2b315bded2799019cea829f8bf57dc6b61efde6611c8",
+                "sha256:707b82d19e65c9bd28b81dde95249b07bf9f5b90ebe1ef17d9b57473f8a64b7b",
+                "sha256:7706f5850360ac01d80c89bcef1640683cc12ed87f42579dab6c5d3ed6888613",
+                "sha256:7782afc9b6b42200f7362858f9e73b1f8316afb276d316336c0ec3bd73312742",
+                "sha256:79983512b108e4a164b9c8d34de3992f76d48cadc9554c9e60b43f308988aabe",
+                "sha256:7f683ddc7eedd742e2889d2bfb96d69573fde1d92fcb811979cdb7165bb9c7d3",
+                "sha256:82357d85de703176b5587dbe6ade8ff67f9f69a41c0733cf2425378b49954de5",
+                "sha256:84450ba661fb96e9fd67629b93d2941c871ca86fc38d835d19d4225ff946a631",
+                "sha256:86f4e8cca779080f66ff4f191a685ced73d2f72d50216f7112185dc02b90b9b7",
+                "sha256:8cda06946eac330cbe6598f77bb54e690b4ca93f593dee1568ad22b04f347c15",
+                "sha256:8ce7fd6767a1cc5a92a639b391891bf1c268b03ec7e021c7d6d902285259685c",
+                "sha256:8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea",
+                "sha256:9289fd5dddcf57bab41d044f1756550f9e7cf0c8e373b8cdf0ce8773dc4bd417",
+                "sha256:92a7e36b000bf022ef3dbb9c46bfe2d52c047d5e3f3343f43204263c5addc250",
+                "sha256:92db3c28b5b2a273346bebb24857fda45601aef6ae1c011c0a997106581e8a88",
+                "sha256:95c3c157765b031331dd4db3c775e58deaee050a3042fcad72cbc4189d7c8dca",
+                "sha256:980b4f289d1d90ca5efcf07958d3eb38ed9c0b7676bf2831a54d4f66f9c27dfa",
+                "sha256:9ae4ef0b3f6b41bad6366fb0ea4fc1d7ed051528e113a60fa2a65a9abb5b1d99",
+                "sha256:9c98230f5042f4945f957d006edccc2af1e03ed5e37ce7c373f00a5a4daa6149",
+                "sha256:9fa2566ca27d67c86569e8c85297aaf413ffab85a8960500f12ea34ff98e4c41",
+                "sha256:a14969b8691f7998e74663b77b4c36c0337cb1df552da83d5c9004a93afdb574",
+                "sha256:a8aacce6e2e1edcb6ac625fb0f8c3a9570ccc7bfba1f63419b3769ccf6a00ed0",
+                "sha256:a8e538f46104c815be19c975572d74afb53f29650ea2025bbfaef359d2de2f7f",
+                "sha256:aa41e526a5d4a9dfcfbab0716c7e8a1b215abd3f3df5a45cf18a12721d31cb5d",
+                "sha256:aa693779a8b50cd97570e5a0f343538a8dbd3e496fa5dcb87e29406ad0299654",
+                "sha256:ab22fbd9765e6954bc0bcff24c25ff71dcbfdb185fcdaca49e81bac68fe724d3",
+                "sha256:ab2e5bef076f5a235c3774b4f4028a680432cded7cad37bba0fd90d64b187d19",
+                "sha256:ab973df98fc99ab39080bfb0eb3a925181454d7c3ac8a1e695fddfae696d9e90",
+                "sha256:af73657b7a68211996527dbfeffbb0864e043d270580c5aef06dc4b659a4b578",
+                "sha256:b197e7094f232959f8f20541ead1d9862ac5ebea1d58e9849c1bf979255dfac9",
+                "sha256:b295729485b06c1a0683af02a9e42d2caa9db04a373dc38a6a58cdd1e8abddf1",
+                "sha256:b8831399554b92b72af5932cdbbd4ddc55c55f631bb13ff8fe4e6536a06c5c51",
+                "sha256:b8dcd239c743aa2f9c22ce674a145e0a25cb1566c495928440a181ca1ccf6719",
+                "sha256:bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236",
+                "sha256:bd7af3717683bea4c87acd8c0d3d5b44d56120b26fd3f8a692bdd2d5260c620a",
+                "sha256:bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c",
+                "sha256:c3e446d253bd88f6377260d07c895816ebf33ffffd56c1c792b13bff9c3e1ade",
+                "sha256:c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944",
+                "sha256:c94057af19bc953643a33581844649a7fdab902624d2eb739738a30e2b3e60fc",
+                "sha256:cab5d0b79d987c67f3b9e9c53f54a61360422a5a0bc075f43cab5621d530c3b6",
+                "sha256:ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6",
+                "sha256:cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27",
+                "sha256:d5b054862739d276e09928de37c79ddeec42a6e1bfc55863be96a36ba22926f6",
+                "sha256:dbe03226baf438ac4fda9e2d0715022fd579cb641c4cf639fa40d53b2fe6f3e2",
+                "sha256:dc15e99b2d8a656f8e666854404f1ba54765871104e50c8e9813af8a7db07f12",
+                "sha256:dcaf7c1524c0542ee2fc82cc8ec337f7a9f7edee2532421ab200d2b920fc97cf",
+                "sha256:dd4eda173a9fcccb5f2e2bd2a9f423d180194b1bf17cf59e3269899235b2a114",
+                "sha256:dd9a8bd8900e65504a305bf8ae6fa9fbc66de94178c420791d0293702fce2df7",
+                "sha256:de7376c29d95d6719048c194a9cf1a1b0393fbe8488a22008610b0361d834ecf",
+                "sha256:e7fdd52961feb4c96507aa649550ec2a0d527c086d284749b2f582f2d40a2e0d",
+                "sha256:e91f541a85298cf35433bf66f3fab2a4a2cff05c127eeca4af174f6d497f0d4b",
+                "sha256:e9e3c4c9e1ed40ea53acf11e2a386383c3304212c965773704e4603d589343ed",
+                "sha256:ee803480535c44e7f5ad00788526da7d85525cfefaf8acf8ab9a310000be4b03",
+                "sha256:f09cb5a7bbe1ecae6e87901a2eb23e0256bb524a79ccc53eb0b7629fbe7677c4",
+                "sha256:f19c1585933c82098c2a520f8ec1227f20e339e33aca8fa6f956f6691b784e67",
+                "sha256:f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365",
+                "sha256:f28f891ccd15c514a0981f3b9db9aa23d62fe1a99997512b0491d2ed323d229a",
+                "sha256:f3e73a4255342d4eb26ef6df01e3962e73aa29baa3124a8e824c5d3364a65748",
+                "sha256:f606a1881d2663630ea5b8ce2efe2111740df4b687bd78b34a8131baa007f79b",
+                "sha256:fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079",
+                "sha256:ffc519621dce0c767e96b9c53f09c5d215578e10b02c285809f76509a3931482"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==3.3.2"
+            "version": "==3.4.0"
         },
         "idna": {
             "hashes": [
@@ -180,11 +195,11 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6",
-                "sha256:eca1c20de70a39daee580aef4986996620f365c4e0fda6a86100231d62f1bf69"
+                "sha256:263ed587a5803c6c708d3ce44dc4dfedaab4c1a32e8329bab818933d79ddcf5d",
+                "sha256:4f50ed74ab84d474ce614475e0b8d5047ff080810aac5d01ea25231cfc944b0c"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.10.2"
+            "version": "==0.10.3"
         },
         "six": {
             "hashes": [
@@ -212,86 +227,122 @@
         }
     },
     "develop": {
+        "black": {
+            "hashes": [
+                "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f",
+                "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd",
+                "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea",
+                "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981",
+                "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b",
+                "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7",
+                "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8",
+                "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175",
+                "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d",
+                "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392",
+                "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad",
+                "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f",
+                "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f",
+                "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b",
+                "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875",
+                "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3",
+                "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800",
+                "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65",
+                "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2",
+                "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812",
+                "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50",
+                "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==24.10.0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.7"
+        },
         "coverage": {
             "extras": [
                 "toml"
             ],
             "hashes": [
-                "sha256:06a737c882bd26d0d6ee7269b20b12f14a8704807a01056c80bb881a4b2ce6ca",
-                "sha256:07e2ca0ad381b91350c0ed49d52699b625aab2b44b65e1b4e02fa9df0e92ad2d",
-                "sha256:0c0420b573964c760df9e9e86d1a9a622d0d27f417e1a949a8a66dd7bcee7bc6",
-                "sha256:0dbde0f4aa9a16fa4d754356a8f2e36296ff4d83994b2c9d8398aa32f222f989",
-                "sha256:1125ca0e5fd475cbbba3bb67ae20bd2c23a98fac4e32412883f9bcbaa81c314c",
-                "sha256:13b0a73a0896988f053e4fbb7de6d93388e6dd292b0d87ee51d106f2c11b465b",
-                "sha256:166811d20dfea725e2e4baa71fffd6c968a958577848d2131f39b60043400223",
-                "sha256:170d444ab405852903b7d04ea9ae9b98f98ab6d7e63e1115e82620807519797f",
-                "sha256:1f4aa8219db826ce6be7099d559f8ec311549bfc4046f7f9fe9b5cea5c581c56",
-                "sha256:225667980479a17db1048cb2bf8bfb39b8e5be8f164b8f6628b64f78a72cf9d3",
-                "sha256:260933720fdcd75340e7dbe9060655aff3af1f0c5d20f46b57f262ab6c86a5e8",
-                "sha256:2bdb062ea438f22d99cba0d7829c2ef0af1d768d1e4a4f528087224c90b132cb",
-                "sha256:2c09f4ce52cb99dd7505cd0fc8e0e37c77b87f46bc9c1eb03fe3bc9991085388",
-                "sha256:3115a95daa9bdba70aea750db7b96b37259a81a709223c8448fa97727d546fe0",
-                "sha256:3e0cadcf6733c09154b461f1ca72d5416635e5e4ec4e536192180d34ec160f8a",
-                "sha256:3f1156e3e8f2872197af3840d8ad307a9dd18e615dc64d9ee41696f287c57ad8",
-                "sha256:4421712dbfc5562150f7554f13dde997a2e932a6b5f352edcce948a815efee6f",
-                "sha256:44df346d5215a8c0e360307d46ffaabe0f5d3502c8a1cefd700b34baf31d411a",
-                "sha256:502753043567491d3ff6d08629270127e0c31d4184c4c8d98f92c26f65019962",
-                "sha256:547f45fa1a93154bd82050a7f3cddbc1a7a4dd2a9bf5cb7d06f4ae29fe94eaf8",
-                "sha256:5621a9175cf9d0b0c84c2ef2b12e9f5f5071357c4d2ea6ca1cf01814f45d2391",
-                "sha256:609b06f178fe8e9f89ef676532760ec0b4deea15e9969bf754b37f7c40326dbc",
-                "sha256:645786266c8f18a931b65bfcefdbf6952dd0dea98feee39bd188607a9d307ed2",
-                "sha256:6878ef48d4227aace338d88c48738a4258213cd7b74fd9a3d4d7582bb1d8a155",
-                "sha256:6a89ecca80709d4076b95f89f308544ec8f7b4727e8a547913a35f16717856cb",
-                "sha256:6db04803b6c7291985a761004e9060b2bca08da6d04f26a7f2294b8623a0c1a0",
-                "sha256:6e2cd258d7d927d09493c8df1ce9174ad01b381d4729a9d8d4e38670ca24774c",
-                "sha256:6e81d7a3e58882450ec4186ca59a3f20a5d4440f25b1cff6f0902ad890e6748a",
-                "sha256:702855feff378050ae4f741045e19a32d57d19f3e0676d589df0575008ea5004",
-                "sha256:78b260de9790fd81e69401c2dc8b17da47c8038176a79092a89cb2b7d945d060",
-                "sha256:7bb65125fcbef8d989fa1dd0e8a060999497629ca5b0efbca209588a73356232",
-                "sha256:7dea0889685db8550f839fa202744652e87c60015029ce3f60e006f8c4462c93",
-                "sha256:8284cf8c0dd272a247bc154eb6c95548722dce90d098c17a883ed36e67cdb129",
-                "sha256:877abb17e6339d96bf08e7a622d05095e72b71f8afd8a9fefc82cf30ed944163",
-                "sha256:8929543a7192c13d177b770008bc4e8119f2e1f881d563fc6b6305d2d0ebe9de",
-                "sha256:8ae539519c4c040c5ffd0632784e21b2f03fc1340752af711f33e5be83a9d6c6",
-                "sha256:8f59d57baca39b32db42b83b2a7ba6f47ad9c394ec2076b084c3f029b7afca23",
-                "sha256:9054a0754de38d9dbd01a46621636689124d666bad1936d76c0341f7d71bf569",
-                "sha256:953510dfb7b12ab69d20135a0662397f077c59b1e6379a768e97c59d852ee51d",
-                "sha256:95cae0efeb032af8458fc27d191f85d1717b1d4e49f7cb226cf526ff28179778",
-                "sha256:9bc572be474cafb617672c43fe989d6e48d3c83af02ce8de73fff1c6bb3c198d",
-                "sha256:9c56863d44bd1c4fe2abb8a4d6f5371d197f1ac0ebdee542f07f35895fc07f36",
-                "sha256:9e0b2df163b8ed01d515807af24f63de04bebcecbd6c3bfeff88385789fdf75a",
-                "sha256:a09ece4a69cf399510c8ab25e0950d9cf2b42f7b3cb0374f95d2e2ff594478a6",
-                "sha256:a1ac0ae2b8bd743b88ed0502544847c3053d7171a3cff9228af618a068ed9c34",
-                "sha256:a318d68e92e80af8b00fa99609796fdbcdfef3629c77c6283566c6f02c6d6704",
-                "sha256:a4acd025ecc06185ba2b801f2de85546e0b8ac787cf9d3b06e7e2a69f925b106",
-                "sha256:a6d3adcf24b624a7b778533480e32434a39ad8fa30c315208f6d3e5542aeb6e9",
-                "sha256:a78d169acd38300060b28d600344a803628c3fd585c912cacc9ea8790fe96862",
-                "sha256:a95324a9de9650a729239daea117df21f4b9868ce32e63f8b650ebe6cef5595b",
-                "sha256:abd5fd0db5f4dc9289408aaf34908072f805ff7792632250dcb36dc591d24255",
-                "sha256:b06079abebbc0e89e6163b8e8f0e16270124c154dc6e4a47b413dd538859af16",
-                "sha256:b43c03669dc4618ec25270b06ecd3ee4fa94c7f9b3c14bae6571ca00ef98b0d3",
-                "sha256:b48f312cca9621272ae49008c7f613337c53fadca647d6384cc129d2996d1133",
-                "sha256:b5d7b556859dd85f3a541db6a4e0167b86e7273e1cdc973e5b175166bb634fdb",
-                "sha256:b9f222de8cded79c49bf184bdbc06630d4c58eec9459b939b4a690c82ed05657",
-                "sha256:c3c02d12f837d9683e5ab2f3d9844dc57655b92c74e286c262e0fc54213c216d",
-                "sha256:c44fee9975f04b33331cb8eb272827111efc8930cfd582e0320613263ca849ca",
-                "sha256:cf4b19715bccd7ee27b6b120e7e9dd56037b9c0681dcc1adc9ba9db3d417fa36",
-                "sha256:d0c212c49b6c10e6951362f7c6df3329f04c2b1c28499563d4035d964ab8e08c",
-                "sha256:d3296782ca4eab572a1a4eca686d8bfb00226300dcefdf43faa25b5242ab8a3e",
-                "sha256:d85f5e9a5f8b73e2350097c3756ef7e785f55bd71205defa0bfdaf96c31616ff",
-                "sha256:da511e6ad4f7323ee5702e6633085fb76c2f893aaf8ce4c51a0ba4fc07580ea7",
-                "sha256:e05882b70b87a18d937ca6768ff33cc3f72847cbc4de4491c8e73880766718e5",
-                "sha256:e61c0abb4c85b095a784ef23fdd4aede7a2628478e7baba7c5e3deba61070a02",
-                "sha256:e6a08c0be454c3b3beb105c0596ebdc2371fab6bb90c0c0297f4e58fd7e1012c",
-                "sha256:e9a6e0eb86070e8ccaedfbd9d38fec54864f3125ab95419970575b42af7541df",
-                "sha256:ed37bd3c3b063412f7620464a9ac1314d33100329f39799255fb8d3027da50d3",
-                "sha256:f1adfc8ac319e1a348af294106bc6a8458a0f1633cc62a1446aebc30c5fa186a",
-                "sha256:f5796e664fe802da4f57a168c85359a8fbf3eab5e55cd4e4569fbacecc903959",
-                "sha256:fc5a77d0c516700ebad189b587de289a20a78324bc54baee03dd486f0855d234",
-                "sha256:fd21f6ae3f08b41004dfb433fa895d858f3f5979e7762d052b12aef444e29afc"
+                "sha256:078a87519057dacb5d77e333f740708ec2a8f768655f1db07f8dfd28d7a005f0",
+                "sha256:087932079c065d7b8ebadd3a0160656c55954144af6439886c8bcf78bbbcde7f",
+                "sha256:0bbae11c138585c89fb4e991faefb174a80112e1a7557d507aaa07675c62e66b",
+                "sha256:0ff2ef83d6d0b527b5c9dad73819b24a2f76fdddcfd6c4e7a4d7e73ecb0656b4",
+                "sha256:12179eb0575b8900912711688e45474f04ab3934aaa7b624dea7b3c511ecc90f",
+                "sha256:1e5e92e3e84a8718d2de36cd8387459cba9a4508337b8c5f450ce42b87a9e760",
+                "sha256:2186369a654a15628e9c1c9921409a6b3eda833e4b91f3ca2a7d9f77abb4987c",
+                "sha256:21c0ea0d4db8a36b275cb6fb2437a3715697a4ba3cb7b918d3525cc75f726304",
+                "sha256:24500f4b0e03aab60ce575c85365beab64b44d4db837021e08339f61d1fbfe52",
+                "sha256:2b636a301e53964550e2f3094484fa5a96e699db318d65398cfba438c5c92171",
+                "sha256:343056c5e0737487a5291f5691f4dfeb25b3e3c8699b4d36b92bb0e586219d14",
+                "sha256:35a51598f29b2a19e26d0908bd196f771a9b1c5d9a07bf20be0adf28f1ad4f77",
+                "sha256:39d3b964abfe1519b9d313ab28abf1d02faea26cd14b27f5283849bf59479ff5",
+                "sha256:3ec528ae69f0a139690fad6deac8a7d33629fa61ccce693fdd07ddf7e9931fba",
+                "sha256:47ccb6e99a3031ffbbd6e7cc041e70770b4fe405370c66a54dbf26a500ded80b",
+                "sha256:4eea60c79d36a8f39475b1af887663bc3ae4f31289cd216f514ce18d5938df40",
+                "sha256:536f77f2bf5797983652d1d55f1a7272a29afcc89e3ae51caa99b2db4e89d658",
+                "sha256:5ed69befa9a9fc796fe015a7040c9398722d6b97df73a6b608e9e275fa0932b0",
+                "sha256:62ab4231c01e156ece1b3a187c87173f31cbeee83a5e1f6dff17f288dca93345",
+                "sha256:667952739daafe9616db19fbedbdb87917eee253ac4f31d70c7587f7ab531b4e",
+                "sha256:69f251804e052fc46d29d0e7348cdc5fcbfc4861dc4a1ebedef7e78d241ad39e",
+                "sha256:6c2ba1e0c24d8fae8f2cf0aeb2fc0a2a7f69b6d20bd8d3749fd6b36ecef5edf0",
+                "sha256:6e85830eed5b5263ffa0c62428e43cb844296f3b4461f09e4bdb0d44ec190bc2",
+                "sha256:7571e8bbecc6ac066256f9de40365ff833553e2e0c0c004f4482facb131820ef",
+                "sha256:7781f4f70c9b0b39e1b129b10c7d43a4e0c91f90c60435e6da8288efc2b73438",
+                "sha256:7926d8d034e06b479797c199747dd774d5e86179f2ce44294423327a88d66ca7",
+                "sha256:7b80fbb0da3aebde102a37ef0138aeedff45997e22f8962e5f16ae1742852676",
+                "sha256:7fca4a92c8a7a73dee6946471bce6d1443d94155694b893b79e19ca2a540d86e",
+                "sha256:84c4315577f7cd511d6250ffd0f695c825efe729f4205c0340f7004eda51191f",
+                "sha256:8d9c5d13927d77af4fbe453953810db766f75401e764727e73a6ee4f82527b3e",
+                "sha256:9681516288e3dcf0aa7c26231178cc0be6cac9705cac06709f2353c5b406cfea",
+                "sha256:97df87e1a20deb75ac7d920c812e9326096aa00a9a4b6d07679b4f1f14b06c90",
+                "sha256:9bcd51eeca35a80e76dc5794a9dd7cb04b97f0e8af620d54711793bfc1fbba4b",
+                "sha256:9c6b0c1cafd96213a0327cf680acb39f70e452caf8e9a25aeb05316db9c07f89",
+                "sha256:a5f81e68aa62bc0cfca04f7b19eaa8f9c826b53fc82ab9e2121976dc74f131f3",
+                "sha256:a663b180b6669c400b4630a24cc776f23a992d38ce7ae72ede2a397ce6b0f170",
+                "sha256:a7b2e437fbd8fae5bc7716b9c7ff97aecc95f0b4d56e4ca08b3c8d8adcaadb84",
+                "sha256:a867d26f06bcd047ef716175b2696b315cb7571ccb951006d61ca80bbc356e9e",
+                "sha256:aa68a6cdbe1bc6793a9dbfc38302c11599bbe1837392ae9b1d238b9ef3dafcf1",
+                "sha256:ab31fdd643f162c467cfe6a86e9cb5f1965b632e5e65c072d90854ff486d02cf",
+                "sha256:ad4ef1c56b47b6b9024b939d503ab487231df1f722065a48f4fc61832130b90e",
+                "sha256:b92f9ca04b3e719d69b02dc4a69debb795af84cb7afd09c5eb5d54b4a1ae2191",
+                "sha256:bb21bac7783c1bf6f4bbe68b1e0ff0d20e7e7732cfb7995bc8d96e23aa90fc7b",
+                "sha256:bf4eeecc9e10f5403ec06138978235af79c9a79af494eb6b1d60a50b49ed2869",
+                "sha256:bfde025e2793a22efe8c21f807d276bd1d6a4bcc5ba6f19dbdfc4e7a12160909",
+                "sha256:c37faddc8acd826cfc5e2392531aba734b229741d3daec7f4c777a8f0d4993e5",
+                "sha256:c71965d1ced48bf97aab79fad56df82c566b4c498ffc09c2094605727c4b7e36",
+                "sha256:c9192925acc33e146864b8cf037e2ed32a91fdf7644ae875f5d46cd2ef086a5f",
+                "sha256:c9df1950fb92d49970cce38100d7e7293c84ed3606eaa16ea0b6bc27175bb667",
+                "sha256:cdfcf2e914e2ba653101157458afd0ad92a16731eeba9a611b5cbb3e7124e74b",
+                "sha256:d03a060ac1a08e10589c27d509bbdb35b65f2d7f3f8d81cf2fa199877c7bc58a",
+                "sha256:d20c3d1f31f14d6962a4e2f549c21d31e670b90f777ef4171be540fb7fb70f02",
+                "sha256:e4ee15b267d2dad3e8759ca441ad450c334f3733304c55210c2a44516e8d5530",
+                "sha256:e8ea055b3ea046c0f66217af65bc193bbbeca1c8661dc5fd42698db5795d2627",
+                "sha256:ebabdf1c76593a09ee18c1a06cd3022919861365219ea3aca0247ededf6facd6",
+                "sha256:ebc94fadbd4a3f4215993326a6a00e47d79889391f5659bf310f55fe5d9f581c",
+                "sha256:ed5ac02126f74d190fa2cc14a9eb2a5d9837d5863920fa472b02eb1595cdc925",
+                "sha256:f01e53575f27097d75d42de33b1b289c74b16891ce576d767ad8c48d17aeb5e0",
+                "sha256:f361296ca7054f0936b02525646b2731b32c8074ba6defab524b79b2b7eeac72",
+                "sha256:f9035695dadfb397bee9eeaf1dc7fbeda483bf7664a7397a629846800ce6e276",
+                "sha256:fcad7d5d2bbfeae1026b395036a8aa5abf67e8038ae7e6a25c7d0f88b10a8e6a",
+                "sha256:ff797320dcbff57caa6b2301c3913784a010e13b1f6cf4ab3f563f3c5e7919db"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==7.6.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==7.6.2"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38",
+                "sha256:597477df7860daa5aa0fdd84bf5208a043ab96b8e96ab708770ae0364dd03213"
+            ],
+            "index": "pypi",
+            "markers": "python_full_version >= '3.8.1'",
+            "version": "==7.1.1"
         },
         "iniconfig": {
             "hashes": [
@@ -301,6 +352,31 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.0.0"
         },
+        "isort": {
+            "hashes": [
+                "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109",
+                "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
+            ],
+            "index": "pypi",
+            "markers": "python_full_version >= '3.8.0'",
+            "version": "==5.13.2"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.0"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
+        },
         "packaging": {
             "hashes": [
                 "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
@@ -309,6 +385,22 @@
             "markers": "python_version >= '3.8'",
             "version": "==24.1"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08",
+                "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.12.1"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907",
+                "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.3.6"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
@@ -316,6 +408,22 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==1.5.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3",
+                "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.12.1"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f",
+                "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.2.0"
         },
         "pytest": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fdd3d16354d9867821a5267b651a7320aaadeccbd7d12f241ff64f2990691003"
+            "sha256": "d3763dcc8676e85ef898c038260d928bd83fd5f8aa210c6eb3cdd3e1543ea08e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -256,6 +256,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==24.10.0"
         },
+        "cfgv": {
+            "hashes": [
+                "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9",
+                "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.4.0"
+        },
         "click": {
             "hashes": [
                 "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
@@ -335,6 +343,21 @@
             "markers": "python_version >= '3.9'",
             "version": "==7.6.2"
         },
+        "distlib": {
+            "hashes": [
+                "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87",
+                "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"
+            ],
+            "version": "==0.3.9"
+        },
+        "filelock": {
+            "hashes": [
+                "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0",
+                "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.16.1"
+        },
         "flake8": {
             "hashes": [
                 "sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38",
@@ -343,6 +366,14 @@
             "index": "pypi",
             "markers": "python_full_version >= '3.8.1'",
             "version": "==7.1.1"
+        },
+        "identify": {
+            "hashes": [
+                "sha256:53863bcac7caf8d2ed85bd20312ea5dcfc22226800f6d6881f232d861db5a8f0",
+                "sha256:91478c5fb7c3aac5ff7bf9b4344f803843dc586832d5f110d672b19aa1984c98"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.6.1"
         },
         "iniconfig": {
             "hashes": [
@@ -377,6 +408,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==1.0.0"
         },
+        "nodeenv": {
+            "hashes": [
+                "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f",
+                "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==1.9.1"
+        },
         "packaging": {
             "hashes": [
                 "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
@@ -408,6 +447,15 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==1.5.0"
+        },
+        "pre-commit": {
+            "hashes": [
+                "sha256:80905ac375958c0444c65e9cebebd948b3cdb518f335a091a670a89d652139d2",
+                "sha256:efde913840816312445dc98787724647c65473daefe420785f885e8ed9a06878"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==4.0.1"
         },
         "pycodestyle": {
             "hashes": [
@@ -442,6 +490,73 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==5.0.0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff",
+                "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48",
+                "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086",
+                "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e",
+                "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133",
+                "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5",
+                "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484",
+                "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee",
+                "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5",
+                "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68",
+                "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a",
+                "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf",
+                "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99",
+                "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8",
+                "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85",
+                "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19",
+                "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc",
+                "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a",
+                "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1",
+                "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317",
+                "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c",
+                "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631",
+                "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d",
+                "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652",
+                "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5",
+                "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e",
+                "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b",
+                "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8",
+                "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476",
+                "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706",
+                "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563",
+                "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237",
+                "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b",
+                "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083",
+                "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180",
+                "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425",
+                "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e",
+                "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f",
+                "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725",
+                "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183",
+                "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab",
+                "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774",
+                "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725",
+                "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e",
+                "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5",
+                "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d",
+                "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290",
+                "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44",
+                "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed",
+                "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4",
+                "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba",
+                "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12",
+                "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==6.0.2"
+        },
+        "virtualenv": {
+            "hashes": [
+                "sha256:280aede09a2a5c317e409a00102e7077c6432c5a38f0ef938e643805a7ad2c48",
+                "sha256:7345cc5b25405607a624d8418154577459c3e0277f5466dd79c49d5e492995f2"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==20.26.6"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+
 # aws-common
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 ## Python environment
 ### Installing Pipenv
 Python environment is maintained with Pipenv. To install Pipenv, ensure you have Python and pip installed in your environment and run:
@@ -37,12 +39,30 @@ To install required modules, run:
 ```bash
 pipenv install
 ```
-
+### Setting Up the Development Environment
 To install required modules for development, run:
 ```bash
 pipenv install --dev
 ```
-
+#### Pre-commit Hooks
+We use `pre-commit` to ensure consistent code quality. Install the pre-commit hooks by running:
+```bash
+pipenv run pre-commit install
+```
+#### Code Formatting and Quality Checks
+- To format code with **Black**:
+```bash
+pipenv run black .
+```
+- To sort imports with **isort**:
+```bash
+pipenv run isort .
+```
+- To check code quality with **Flake8**:
+```bash
+pipenv run flake8 .
+```
+These tools help maintain code quality and consistency across the project.
 ## Unit tests
 To run unit tests, after installing required modules for development, run:
 ```bash

--- a/app_common/app_config.py
+++ b/app_common/app_config.py
@@ -5,16 +5,22 @@ Configuration parameters for the whole application.
 import os
 import re
 
+
 def is_valid_email(email: str) -> bool:
     """Check if the provided email is valid using a regex pattern."""
     email_regex = r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"
     return re.match(email_regex, email) is not None
 
+
 try:
     email_recipients_parameter = os.environ["AppDefaultEmailRecipients"]
-    if email_recipients_parameter.strip():  # Check if the string is non-empty after stripping spaces
+    if (
+        email_recipients_parameter.strip()
+    ):  # Check if the string is non-empty after stripping spaces
         AppDefaultEmailRecipients = [
-            x.strip() for x in email_recipients_parameter.split(",") if is_valid_email(x.strip())
+            x.strip()
+            for x in email_recipients_parameter.split(",")
+            if is_valid_email(x.strip())
         ]
     else:
         AppDefaultEmailRecipients = []  # Handle the case where it's an empty string

--- a/app_common/app_utils.py
+++ b/app_common/app_utils.py
@@ -131,16 +131,15 @@ def run_command(command, cwd=None, shell=False):
     :param cwd: The directory to run the command in.
     :param shell: Whether to use a shell to run the command.
     """
-    # Check if running on Windows and replace 'python3.11' with the full path to python.exe
-    if platform.system() == "Windows" and "python3.11" in command:
-        # Use the full path of python3.11
-        # TODO: #17 Fix it getting the correct path from the user's Windows environment
-        # Another option is to use the sys.executable variable, but it may not be the correct version
-        # python_path = r"C:\Users\lsieb\AppData\Local\Programs\Python\Python311\python.exe"
-        new_alias = "python"
-        command = [new_alias if arg == "python3.11" else arg for arg in command]
+    # TODO: #17 Fix it getting the correct path from the user's Windows environment
+    # Replace 'python3.11' with the current Python executable
+    if isinstance(command, list):
+        command = [sys.executable if arg == "python3.11" else arg for arg in command]
+    elif isinstance(command, str):
+        command = command.replace("python3.11", sys.executable)
 
     result = subprocess.run(command, shell=shell, cwd=cwd)
     
     if result.returncode != 0:
-        sys.exit(result.returncode) 
+        sys.exit(result.returncode)
+

--- a/app_common/app_utils.py
+++ b/app_common/app_utils.py
@@ -25,7 +25,9 @@ def get_first_non_none(*args, **kwargs):
     exists.
     """
 
-    return next((arg for arg in list(args) + list(kwargs.values()) if arg is not None), None)
+    return next(
+        (arg for arg in list(args) + list(kwargs.values()) if arg is not None), None
+    )
 
 
 def get_first_element(l: list):
@@ -53,6 +55,7 @@ def str_is_none_or_empty(s) -> bool:
         return True
     return False
 
+
 def is_numeric(x) -> bool:
     """
     Returns `True` in case the input argument is numeric. An argument is
@@ -69,11 +72,10 @@ def is_numeric(x) -> bool:
     except ValueError:
         return False
 
-import pprint
-from collections import deque
 
 import pprint
 from collections import deque
+
 
 def do_log(obj, title=None, log_limit: int = 150):
     """
@@ -81,6 +83,7 @@ def do_log(obj, title=None, log_limit: int = 150):
     If the object is a dictionary, it logs the keys and values.
     If the object is a list, it logs the first 2 elements, indicating it's a sample.
     """
+
     def _indent(level: int = 1, base_chars: str = "---") -> str:
         # Generate indentation string based on the given level
         return "\n" + (base_chars * level)
@@ -92,7 +95,15 @@ def do_log(obj, title=None, log_limit: int = 150):
         current_obj, level = stack.pop()
         if isinstance(current_obj, str):
             # Handle string objects directly, applying truncation if needed
-            output_lines.append(_indent(level) + (current_obj[:log_limit] + "..." if len(current_obj) > log_limit else current_obj) + "\n")
+            output_lines.append(
+                _indent(level)
+                + (
+                    current_obj[:log_limit] + "..."
+                    if len(current_obj) > log_limit
+                    else current_obj
+                )
+                + "\n"
+            )
 
         elif isinstance(current_obj, dict):
             # Handle dictionary objects, logging each key and value
@@ -103,14 +114,20 @@ def do_log(obj, title=None, log_limit: int = 150):
 
         elif isinstance(current_obj, list):
             # Handle list objects, logging the first 2 elements as a sample
-            output_lines.append(_indent(level) + f"[TYPE: {type(current_obj)}] Sample:\n")
+            output_lines.append(
+                _indent(level) + f"[TYPE: {type(current_obj)}] Sample:\n"
+            )
             for item in reversed(current_obj[:2]):
                 stack.append((item, level + 1))
 
         else:
             # Default case for other object types, applying truncation if needed
             obj_str = str(current_obj)
-            output_lines.append(_indent(level) + (obj_str[:log_limit] + "..." if len(obj_str) > log_limit else obj_str) + "\n")
+            output_lines.append(
+                _indent(level)
+                + (obj_str[:log_limit] + "..." if len(obj_str) > log_limit else obj_str)
+                + "\n"
+            )
 
     if title:
         # Print the title if provided
@@ -119,14 +136,17 @@ def do_log(obj, title=None, log_limit: int = 150):
     # Print the generated log for the given object
     print("".join(output_lines))
 
+
+import os
+import platform
 import subprocess
 import sys
-import platform
-import os 
+
+
 def run_command(command, cwd=None, shell=False):
     """
     Run a shell command in the specified directory.
-    
+
     :param command: The command to run.
     :param cwd: The directory to run the command in.
     :param shell: Whether to use a shell to run the command.
@@ -139,7 +159,6 @@ def run_command(command, cwd=None, shell=False):
         command = command.replace("python3.11", sys.executable)
 
     result = subprocess.run(command, shell=shell, cwd=cwd)
-    
+
     if result.returncode != 0:
         sys.exit(result.returncode)
-

--- a/app_common/app_utils.py
+++ b/app_common/app_utils.py
@@ -69,58 +69,55 @@ def is_numeric(x) -> bool:
     except ValueError:
         return False
 
+import pprint
+from collections import deque
+
+import pprint
+from collections import deque
 
 def do_log(obj, title=None, log_limit: int = 150):
     """
-    Logs an object to the console, truncate the content if large.
-    If the object is a dictionary, it logs the keys and recursively logs the values.
-    If the object is a list, it logs the first 10 elements and recursively logs them.
+    Logs an object to the console, truncating the content if large.
+    If the object is a dictionary, it logs the keys and values.
+    If the object is a list, it logs the first 2 elements, indicating it's a sample.
     """
+    def _indent(level: int = 1, base_chars: str = "---") -> str:
+        # Generate indentation string based on the given level
+        return "\n" + (base_chars * level)
 
-    def _indentation_helper(level: int = 1, base_chars: str = "---") -> str:
-        return "\r" + (base_chars * level)
+    output_lines = []
+    stack = deque([(obj, 0)])
 
-    def generate_log_helper(obj, level: int = 0, log_limit: int = log_limit) -> str:
-        type_str = f"[TYPE: {type(obj)}] "
-        obj_str = str(obj)
-        if type(obj) not in {str}:
-            obj_str = type_str + obj_str
+    while stack:
+        current_obj, level = stack.pop()
+        if isinstance(current_obj, str):
+            # Handle string objects directly, applying truncation if needed
+            output_lines.append(_indent(level) + (current_obj[:log_limit] + "..." if len(current_obj) > log_limit else current_obj) + "\n")
 
-        # limit the object string length to avoid logging too much information
-        if len(obj_str) <= log_limit:
-            # object is small enough to log it entirely
-            return _indentation_helper(level=level) + obj_str
-        # else:
-        # object is too large, truncate it
-        obj_str = obj_str[:log_limit] + "..."
+        elif isinstance(current_obj, dict):
+            # Handle dictionary objects, logging each key and value
+            output_lines.append(_indent(level) + f"[TYPE: {type(current_obj)}]\n")
+            for key, value in reversed(current_obj.items()):
+                stack.append((value, level + 2))
+                output_lines.append(_indent(level + 1) + key + "\n")
 
-        if type(obj) in [dict, list]:
-            # update the string to show only the type
-            obj_str = type_str
+        elif isinstance(current_obj, list):
+            # Handle list objects, logging the first 2 elements as a sample
+            output_lines.append(_indent(level) + f"[TYPE: {type(current_obj)}] Sample:\n")
+            for item in reversed(current_obj[:2]):
+                stack.append((item, level + 1))
 
-        # indenting the object string
-        obj_str = _indentation_helper(level=level) + obj_str
-
-        # updating the indentation to show sub-elements in case of dictionaries and lists
-        if isinstance(obj, dict):
-            for key, value in obj.items():
-                obj_str += _indentation_helper(level=level) + f"{key} = "
-                obj_str += generate_log_helper(value, level + 1)
-        elif isinstance(obj, list):
-            obj_str += (
-                _indentation_helper(level=level) + f"Length: {len(obj)}. Sample: "
-            )
-            for i, item in enumerate(obj):
-                if i >= 3:
-                    break
-                obj_str += generate_log_helper(item, level + 1)
-
-        return obj_str
+        else:
+            # Default case for other object types, applying truncation if needed
+            obj_str = str(current_obj)
+            output_lines.append(_indent(level) + (obj_str[:log_limit] + "..." if len(obj_str) > log_limit else obj_str) + "\n")
 
     if title:
+        # Print the title if provided
         print(title)
 
-    print(generate_log_helper(obj))
+    # Print the generated log for the given object
+    print("".join(output_lines))
 
 import subprocess
 import sys

--- a/app_common/base_lambda_handler.py
+++ b/app_common/base_lambda_handler.py
@@ -3,14 +3,15 @@ This module contains the base class for Lambda handlers.
 """
 
 import base64
-from decimal import Decimal
 import json
 import os
 import traceback
 from abc import ABC, abstractmethod
+from decimal import Decimal
 
 import boto3
-from app_common.app_utils import do_log, DecimalEncoder
+
+from app_common.app_utils import DecimalEncoder, do_log
 
 
 class BaseLambdaHandler(ABC):

--- a/app_common/email_util.py
+++ b/app_common/email_util.py
@@ -5,6 +5,7 @@ Email utility functions
 import os
 
 import resend
+
 from app_common.app_config import AppDefaultEmailRecipients
 
 

--- a/app_scripts/app_reset_venv.py
+++ b/app_scripts/app_reset_venv.py
@@ -1,9 +1,11 @@
 """Recreates the Python virtual environment for the project."""
+
 import os
 import shutil
 
 # The directory where the Python virtual environment is stored
 PYTHON_VENV_DIR = ".venv"
+
 
 def do_reset_venv(do_log_func, run_cmd_func):
     """

--- a/app_scripts/app_setup_execution.py
+++ b/app_scripts/app_setup_execution.py
@@ -2,13 +2,15 @@
 This script is used to automate the setup of the Python virtual environment, 
 installation of Python requirements, and the application's deploy.
 """
+
+import importlib.util
 import os
 import sys
-import importlib.util
-from app_test import do_run_tests
-from app_reset_venv import do_reset_venv
-from app_install_reqs import do_install_req
+
 from app_deploy import do_deploy
+from app_install_reqs import do_install_req
+from app_reset_venv import do_reset_venv
+from app_test import do_run_tests
 
 # Set of possible menu options considering the synonyms
 MENU_VENV_OPTIONS = {
@@ -67,6 +69,7 @@ _UTILS_MODULE = importlib.util.module_from_spec(spec)
 sys.modules["app_utils_module"] = _UTILS_MODULE
 spec.loader.exec_module(_UTILS_MODULE)
 
+
 def _do_log(obj, title=None, log_limit: int = 150):
     """
     Wrapper function to call the do_log function from the app_utils module.
@@ -80,11 +83,14 @@ def _run_command(command, cwd=None, shell=False):
     """
     _UTILS_MODULE.run_command(command, cwd=cwd, shell=shell)
 
+
 def main():
     """
     Main function to parse command-line arguments and call the appropriate function.
     """
-    error_msg_args = "Usage: la_setup.py --<setup_venv|install_requirements|deploy|run_tests>"
+    error_msg_args = (
+        "Usage: la_setup.py --<setup_venv|install_requirements|deploy|run_tests>"
+    )
     if len(sys.argv) != 4:
         _do_log(error_msg_args)
         sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88  # Default line length that works well with Flake8
-target-version = ['py38']  # Set to the version of Python you are using
+target-version = ['py311']  # Set to the version of Python you are using
 skip-string-normalization = false
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+line-length = 88  # Default line length that works well with Flake8
+target-version = ['py38']  # Set to the version of Python you are using
+skip-string-normalization = false
+
+[tool.isort]
+profile = "black"
+line_length = 88  # Ensure the line length matches Black and Flake8
+multi_line_output = 3  # Ensure similar line breaks for imports as Black
+include_trailing_comma = true  # Matches Black's default style

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,22 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 # Read version from the VERSION file
 with open("VERSION", "r") as version_file:
     version = version_file.read().strip()
 
 setup(
-    name='aws-common',
-    version='0.1',
+    name="aws-common",
+    version="0.1",
     packages=find_packages(),
-    install_requires=[],    # Pipenv manages dependencies
-    author='LARS AI',
-    author_email='lars-ai@lars-ai.com',
-    description='A shared package for common modules and constants for AWS Lambda applications',
-    url='https://github.com/LARS-Org/aws-common.git',
+    install_requires=[],  # Pipenv manages dependencies
+    author="LARS AI",
+    author_email="lars-ai@lars-ai.com",
+    description="A shared package for common modules and constants for AWS Lambda applications",
+    url="https://github.com/LARS-Org/aws-common.git",
     classifiers=[
-        'Programming Language :: Python :: 3',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-     ],
-     python_requires='>=3.11',
- )
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires=">=3.11",
+)

--- a/tests/test_app_common/test_app_config.py
+++ b/tests/test_app_common/test_app_config.py
@@ -1,20 +1,32 @@
 import os
-import pytest
 from unittest.mock import patch
+
+import pytest
+
 
 # Import the module after environment is mocked
 def reload_module():
     """Helper function to reload the module to apply environment changes"""
     import importlib
+
     import app_common.app_config
+
     importlib.reload(app_common.app_config)
     return app_common.app_config
 
+
 def test_app_default_email_recipients_with_env_var():
     # Test when the environment variable is set
-    with patch.dict(os.environ, {"AppDefaultEmailRecipients": "test1@example.com, test2@example.com"}):
+    with patch.dict(
+        os.environ,
+        {"AppDefaultEmailRecipients": "test1@example.com, test2@example.com"},
+    ):
         config_module = reload_module()
-        assert config_module.AppDefaultEmailRecipients == ["test1@example.com", "test2@example.com"]
+        assert config_module.AppDefaultEmailRecipients == [
+            "test1@example.com",
+            "test2@example.com",
+        ]
+
 
 def test_app_default_email_recipients_without_env_var():
     # Test when the environment variable is not set
@@ -22,11 +34,13 @@ def test_app_default_email_recipients_without_env_var():
         config_module = reload_module()
         assert config_module.AppDefaultEmailRecipients == []
 
+
 def test_app_default_email_recipients_empty_string():
     # Test when the environment variable is set but the value is an empty string
     with patch.dict(os.environ, {"AppDefaultEmailRecipients": ""}):
         config_module = reload_module()
         assert config_module.AppDefaultEmailRecipients == []
+
 
 def test_app_default_email_recipients_single_value():
     # Test when the environment variable contains a single value
@@ -34,21 +48,39 @@ def test_app_default_email_recipients_single_value():
         config_module = reload_module()
         assert config_module.AppDefaultEmailRecipients == ["test@example.com"]
 
+
 def test_valid_emails():
     # Test with valid emails
-    with patch.dict('os.environ', {"AppDefaultEmailRecipients": "test1@example.com, test2@example.com"}):
+    with patch.dict(
+        "os.environ",
+        {"AppDefaultEmailRecipients": "test1@example.com, test2@example.com"},
+    ):
         config_module = reload_module()
-        assert config_module.AppDefaultEmailRecipients == ["test1@example.com", "test2@example.com"]
+        assert config_module.AppDefaultEmailRecipients == [
+            "test1@example.com",
+            "test2@example.com",
+        ]
+
 
 def test_invalid_emails():
     # Test with invalid emails
-    with patch.dict('os.environ', {"AppDefaultEmailRecipients": "test1@example, invalid-email"}):
+    with patch.dict(
+        "os.environ", {"AppDefaultEmailRecipients": "test1@example, invalid-email"}
+    ):
         config_module = reload_module()
         assert config_module.AppDefaultEmailRecipients == []
 
+
 def test_mixed_valid_and_invalid_emails():
     # Test with a mix of valid and invalid emails
-    with patch.dict('os.environ', {"AppDefaultEmailRecipients": "valid1@example.com, invalid-email, valid2@example.com"}):
+    with patch.dict(
+        "os.environ",
+        {
+            "AppDefaultEmailRecipients": "valid1@example.com, invalid-email, valid2@example.com"
+        },
+    ):
         config_module = reload_module()
-        assert config_module.AppDefaultEmailRecipients == ["valid1@example.com", "valid2@example.com"]
-
+        assert config_module.AppDefaultEmailRecipients == [
+            "valid1@example.com",
+            "valid2@example.com",
+        ]

--- a/tests/test_app_common/test_app_utils.py
+++ b/tests/test_app_common/test_app_utils.py
@@ -341,3 +341,56 @@ class TestDoLog:
         """
         do_log([])
         mock_print.assert_called_once_with("\n[TYPE: <class 'list'>] Sample:\n")
+
+from unittest.mock import call
+import subprocess, sys
+from app_common.app_utils import run_command
+
+class TestRunCommand:
+    @patch('subprocess.run')
+    def test_run_command_success(self, mock_subprocess_run):
+        """
+        Test that run_command runs successfully.
+        """
+        mock_subprocess_run.return_value.returncode = 0
+        run_command(["echo", "Hello World"])
+        mock_subprocess_run.assert_called_once_with(["echo", "Hello World"], shell=False, cwd=None)
+
+    @patch('subprocess.run')
+    @patch('sys.exit')
+    def test_run_command_failure(self, mock_sys_exit, mock_subprocess_run):
+        """
+        Test that run_command exits on failure.
+        """
+        mock_subprocess_run.return_value.returncode = 1
+        run_command(["invalid_command"])
+        mock_subprocess_run.assert_called_once_with(["invalid_command"], shell=False, cwd=None)
+        mock_sys_exit.assert_called_once_with(1)
+
+    @patch('subprocess.run')
+    def test_run_command_with_shell(self, mock_subprocess_run):
+        """
+        Test that run_command runs successfully with shell=True.
+        """
+        mock_subprocess_run.return_value.returncode = 0
+        run_command(["echo Hello World"], shell=True)
+        mock_subprocess_run.assert_called_once_with(["echo Hello World"], shell=True, cwd=None)
+
+    @patch('subprocess.run')
+    def test_run_command_with_cwd(self, mock_subprocess_run):
+        """
+        Test that run_command runs successfully with a specific working directory.
+        """
+        mock_subprocess_run.return_value.returncode = 0
+        run_command(["ls"], cwd="/home/user")
+        mock_subprocess_run.assert_called_once_with(["ls"], shell=False, cwd="/home/user")
+
+    @patch('subprocess.run')
+    def test_run_command_replace_python(self, mock_subprocess_run):
+        """
+        Test that run_command replaces 'python3.11' with the current Python executable.
+        """
+        mock_subprocess_run.return_value.returncode = 0
+        run_command(["python3.11", "--version"])
+        mock_subprocess_run.assert_called_once_with([sys.executable, "--version"], shell=False, cwd=None)
+

--- a/tests/test_app_common/test_app_utils.py
+++ b/tests/test_app_common/test_app_utils.py
@@ -1,7 +1,7 @@
 import json
 import decimal
 import pytest
-from app_common.app_utils import DecimalEncoder, get_first_non_none, get_first_element, str_is_none_or_empty, is_numeric
+from app_common.app_utils import DecimalEncoder, get_first_non_none, get_first_element, str_is_none_or_empty, is_numeric, do_log
 
 class TestDecimalEncoder:
     def test_decimal_encoder_with_decimal(self):
@@ -273,3 +273,71 @@ class TestIsNumeric:
         result = is_numeric("   ")
         assert result is False
 
+import pprint
+from unittest.mock import patch
+from app_common.app_utils import do_log
+
+class TestDoLog:
+    @patch('builtins.print')
+    def test_do_log_string(self, mock_print):
+        """
+        Test logging a simple string.
+        """
+        test_str = "Hello, this is a test."
+        do_log(test_str)
+        mock_print.assert_called_once_with("\nHello, this is a test.\n")
+
+    @patch('builtins.print')
+    def test_do_log_truncated_string(self, mock_print):
+        """
+        Test logging a long string that should be truncated.
+        """
+        test_str = "a" * 200
+        do_log(test_str, log_limit=50)
+        mock_print.assert_called_once_with("\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n")
+
+    @patch('builtins.print')
+    def test_do_log_with_title(self, mock_print):
+        """
+        Test logging with a title.
+        """
+        test_str = "Test string"
+        do_log(test_str, title="Title")
+        mock_print.assert_any_call("Title")
+        mock_print.assert_any_call("\nTest string\n")
+
+    @patch('builtins.print')
+    def test_do_log_dictionary(self, mock_print):
+        """
+        Test logging a dictionary.
+        """
+        test_dict = {"key1": "value1", "key2": {"subkey1": "subvalue1"}}
+        do_log(test_dict, log_limit=50)
+        calls = [call[0][0] for call in mock_print.call_args_list]
+        assert "\n[TYPE: <class 'dict'>]\n\n---key2\n\n---key1\n\n------value1\n\n------[TYPE: <class 'dict'>]\n\n---------subkey1\n\n------------subvalue1\n" in calls
+
+    @patch('builtins.print')
+    def test_do_log_list(self, mock_print):
+        """
+        Test logging a list.
+        """
+        test_list = ["element1", "element2", "element3"]
+        do_log(test_list, log_limit=50)
+        calls = [call[0][0] for call in mock_print.call_args_list]
+        assert "\n[TYPE: <class 'list'>] Sample:\n\n---element1\n\n---element2\n" in calls
+
+    @patch('builtins.print')
+    def test_do_log_empty_dictionary(self, mock_print):
+        """
+        Test logging an empty dictionary.
+        """
+        do_log({})
+        mock_print.assert_called_once_with("\n[TYPE: <class 'dict'>]\n")
+
+    @patch('builtins.print')
+    def test_do_log_empty_list(self, mock_print):
+        """
+        Test logging an empty list.
+        """
+        do_log([])
+        mock_print.assert_called_once_with("\n[TYPE: <class 'list'>] Sample:\n")

--- a/tests/test_app_common/test_app_utils.py
+++ b/tests/test_app_common/test_app_utils.py
@@ -342,6 +342,48 @@ class TestDoLog:
         do_log([])
         mock_print.assert_called_once_with("\n[TYPE: <class 'list'>] Sample:\n")
 
+    @patch('builtins.print')
+    def test_do_log_default_case_int(self, mock_print):
+        """
+        Test logging an integer (default case).
+        """
+        do_log(42, log_limit=50)
+        mock_print.assert_called_once_with("\n42\n")
+
+    @patch('builtins.print')
+    def test_do_log_default_case_float(self, mock_print):
+        """
+        Test logging a float (default case).
+        """
+        do_log(3.14159, log_limit=50)
+        mock_print.assert_called_once_with("\n3.14159\n")
+
+    @patch('builtins.print')
+    def test_do_log_default_case_object(self, mock_print):
+        """
+        Test logging an object instance (default case).
+        """
+        class SampleObject:
+            def __str__(self):
+                return "SampleObjectRepresentation"
+
+        obj = SampleObject()
+        do_log(obj, log_limit=50)
+        mock_print.assert_called_once_with("\nSampleObjectRepresentation\n")
+
+    @patch('builtins.print')
+    def test_do_log_truncated_object(self, mock_print):
+        """
+        Test logging a long object string representation that should be truncated.
+        """
+        class SampleObject:
+            def __str__(self):
+                return "A" * 200
+
+        obj = SampleObject()
+        do_log(obj, log_limit=50)
+        mock_print.assert_called_once_with("\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...\n")
+
 from unittest.mock import call
 import subprocess, sys
 from app_common.app_utils import run_command
@@ -394,3 +436,20 @@ class TestRunCommand:
         run_command(["python3.11", "--version"])
         mock_subprocess_run.assert_called_once_with([sys.executable, "--version"], shell=False, cwd=None)
 
+    @patch('subprocess.run')
+    def test_run_command_string_command(self, mock_subprocess_run):
+        """
+        Test run_command with a string command to ensure replacement of 'python3.11' with sys.executable.
+        """
+        mock_subprocess_run.return_value.returncode = 0
+        run_command("python3.11 --version", shell=True)
+        mock_subprocess_run.assert_called_once_with(f"{sys.executable} --version", shell=True, cwd=None)
+
+    @patch('subprocess.run')
+    def test_run_command_string_command_no_replacement(self, mock_subprocess_run):
+        """
+        Test run_command with a string command that does not require replacement.
+        """
+        mock_subprocess_run.return_value.returncode = 0
+        run_command("echo Hello World", shell=True)
+        mock_subprocess_run.assert_called_once_with("echo Hello World", shell=True, cwd=None)

--- a/tests/test_app_common/test_app_utils.py
+++ b/tests/test_app_common/test_app_utils.py
@@ -1,7 +1,17 @@
-import json
 import decimal
+import json
+
 import pytest
-from app_common.app_utils import DecimalEncoder, get_first_non_none, get_first_element, str_is_none_or_empty, is_numeric, do_log
+
+from app_common.app_utils import (
+    DecimalEncoder,
+    do_log,
+    get_first_element,
+    get_first_non_none,
+    is_numeric,
+    str_is_none_or_empty,
+)
+
 
 class TestDecimalEncoder:
     def test_decimal_encoder_with_decimal(self):
@@ -22,10 +32,12 @@ class TestDecimalEncoder:
             "decimal": decimal.Decimal("99.99"),
             "string": "example",
             "int": 42,
-            "float": 1.234
+            "float": 1.234,
         }
         json_data = json.dumps(data, cls=DecimalEncoder)
-        expected_json = '{"decimal": "99.99", "string": "example", "int": 42, "float": 1.234}'
+        expected_json = (
+            '{"decimal": "99.99", "string": "example", "int": 42, "float": 1.234}'
+        )
         assert json_data == expected_json
 
     def test_decimal_encoder_with_nested_data(self):
@@ -33,19 +45,24 @@ class TestDecimalEncoder:
         data = {
             "nested": {
                 "price": decimal.Decimal("199.99"),
-                "description": "example product"
+                "description": "example product",
             }
         }
         json_data = json.dumps(data, cls=DecimalEncoder)
-        expected_json = '{"nested": {"price": "199.99", "description": "example product"}}'
+        expected_json = (
+            '{"nested": {"price": "199.99", "description": "example product"}}'
+        )
         assert json_data == expected_json
 
     def test_decimal_encoder_invalid_data(self):
         # Test that the encoder raises a TypeError for objects that can't be encoded (without handling by DecimalEncoder)
         with pytest.raises(TypeError):
+
             class CustomObject:
                 pass
+
             json.dumps({"obj": CustomObject()}, cls=DecimalEncoder)
+
 
 class TestGetFirstNonNone:
     def test_get_first_non_none_with_all_none_args(self):
@@ -104,6 +121,7 @@ class TestGetFirstNonNone:
         result = get_first_non_none(None, 99, a=100, b=None)
         assert result == 99
 
+
 class TestGetFirstElement:
     def test_get_first_element_empty_list(self):
         """
@@ -131,11 +149,12 @@ class TestGetFirstElement:
         Test that get_first_element raises an error when the input is not a list.
         """
         with pytest.raises(TypeError, match="Expected list, got int"):
-            get_first_element(42)   # Passing a non-list value
+            get_first_element(42)  # Passing a non-list value
         with pytest.raises(TypeError, match="Expected list, got str"):
-            get_first_element("string") # Passing a string
+            get_first_element("string")  # Passing a string
         with pytest.raises(TypeError, match="Expected list, got NoneType"):
-            get_first_element(None) # Passing None
+            get_first_element(None)  # Passing None
+
 
 class TestStrIsNoneOrEmpty:
     def test_str_is_none(self):
@@ -184,6 +203,7 @@ class TestStrIsNoneOrEmpty:
         """
         Test when the input is an object whose string representation is an empty string. The function should return True.
         """
+
         class EmptyStr:
             def __str__(self):
                 return ""
@@ -195,12 +215,14 @@ class TestStrIsNoneOrEmpty:
         """
         Test when the input is an object whose string representation is non-empty. The function should return False.
         """
+
         class NonEmptyStr:
             def __str__(self):
                 return "NonEmpty"
 
         result = str_is_none_or_empty(NonEmptyStr())
         assert result is False
+
 
 class TestIsNumeric:
     def test_is_numeric_with_none(self):
@@ -273,12 +295,15 @@ class TestIsNumeric:
         result = is_numeric("   ")
         assert result is False
 
+
 import pprint
 from unittest.mock import patch
+
 from app_common.app_utils import do_log
 
+
 class TestDoLog:
-    @patch('builtins.print')
+    @patch("builtins.print")
     def test_do_log_string(self, mock_print):
         """
         Test logging a simple string.
@@ -287,16 +312,18 @@ class TestDoLog:
         do_log(test_str)
         mock_print.assert_called_once_with("\nHello, this is a test.\n")
 
-    @patch('builtins.print')
+    @patch("builtins.print")
     def test_do_log_truncated_string(self, mock_print):
         """
         Test logging a long string that should be truncated.
         """
         test_str = "a" * 200
         do_log(test_str, log_limit=50)
-        mock_print.assert_called_once_with("\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n")
+        mock_print.assert_called_once_with(
+            "\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...\n"
+        )
 
-    @patch('builtins.print')
+    @patch("builtins.print")
     def test_do_log_with_title(self, mock_print):
         """
         Test logging with a title.
@@ -306,7 +333,7 @@ class TestDoLog:
         mock_print.assert_any_call("Title")
         mock_print.assert_any_call("\nTest string\n")
 
-    @patch('builtins.print')
+    @patch("builtins.print")
     def test_do_log_dictionary(self, mock_print):
         """
         Test logging a dictionary.
@@ -314,9 +341,12 @@ class TestDoLog:
         test_dict = {"key1": "value1", "key2": {"subkey1": "subvalue1"}}
         do_log(test_dict, log_limit=50)
         calls = [call[0][0] for call in mock_print.call_args_list]
-        assert "\n[TYPE: <class 'dict'>]\n\n---key2\n\n---key1\n\n------value1\n\n------[TYPE: <class 'dict'>]\n\n---------subkey1\n\n------------subvalue1\n" in calls
+        assert (
+            "\n[TYPE: <class 'dict'>]\n\n---key2\n\n---key1\n\n------value1\n\n------[TYPE: <class 'dict'>]\n\n---------subkey1\n\n------------subvalue1\n"
+            in calls
+        )
 
-    @patch('builtins.print')
+    @patch("builtins.print")
     def test_do_log_list(self, mock_print):
         """
         Test logging a list.
@@ -324,9 +354,11 @@ class TestDoLog:
         test_list = ["element1", "element2", "element3"]
         do_log(test_list, log_limit=50)
         calls = [call[0][0] for call in mock_print.call_args_list]
-        assert "\n[TYPE: <class 'list'>] Sample:\n\n---element1\n\n---element2\n" in calls
+        assert (
+            "\n[TYPE: <class 'list'>] Sample:\n\n---element1\n\n---element2\n" in calls
+        )
 
-    @patch('builtins.print')
+    @patch("builtins.print")
     def test_do_log_empty_dictionary(self, mock_print):
         """
         Test logging an empty dictionary.
@@ -334,7 +366,7 @@ class TestDoLog:
         do_log({})
         mock_print.assert_called_once_with("\n[TYPE: <class 'dict'>]\n")
 
-    @patch('builtins.print')
+    @patch("builtins.print")
     def test_do_log_empty_list(self, mock_print):
         """
         Test logging an empty list.
@@ -342,7 +374,7 @@ class TestDoLog:
         do_log([])
         mock_print.assert_called_once_with("\n[TYPE: <class 'list'>] Sample:\n")
 
-    @patch('builtins.print')
+    @patch("builtins.print")
     def test_do_log_default_case_int(self, mock_print):
         """
         Test logging an integer (default case).
@@ -350,7 +382,7 @@ class TestDoLog:
         do_log(42, log_limit=50)
         mock_print.assert_called_once_with("\n42\n")
 
-    @patch('builtins.print')
+    @patch("builtins.print")
     def test_do_log_default_case_float(self, mock_print):
         """
         Test logging a float (default case).
@@ -358,11 +390,12 @@ class TestDoLog:
         do_log(3.14159, log_limit=50)
         mock_print.assert_called_once_with("\n3.14159\n")
 
-    @patch('builtins.print')
+    @patch("builtins.print")
     def test_do_log_default_case_object(self, mock_print):
         """
         Test logging an object instance (default case).
         """
+
         class SampleObject:
             def __str__(self):
                 return "SampleObjectRepresentation"
@@ -371,85 +404,106 @@ class TestDoLog:
         do_log(obj, log_limit=50)
         mock_print.assert_called_once_with("\nSampleObjectRepresentation\n")
 
-    @patch('builtins.print')
+    @patch("builtins.print")
     def test_do_log_truncated_object(self, mock_print):
         """
         Test logging a long object string representation that should be truncated.
         """
+
         class SampleObject:
             def __str__(self):
                 return "A" * 200
 
         obj = SampleObject()
         do_log(obj, log_limit=50)
-        mock_print.assert_called_once_with("\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...\n")
+        mock_print.assert_called_once_with(
+            "\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...\n"
+        )
 
+
+import subprocess
+import sys
 from unittest.mock import call
-import subprocess, sys
+
 from app_common.app_utils import run_command
 
+
 class TestRunCommand:
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_run_command_success(self, mock_subprocess_run):
         """
         Test that run_command runs successfully.
         """
         mock_subprocess_run.return_value.returncode = 0
         run_command(["echo", "Hello World"])
-        mock_subprocess_run.assert_called_once_with(["echo", "Hello World"], shell=False, cwd=None)
+        mock_subprocess_run.assert_called_once_with(
+            ["echo", "Hello World"], shell=False, cwd=None
+        )
 
-    @patch('subprocess.run')
-    @patch('sys.exit')
+    @patch("subprocess.run")
+    @patch("sys.exit")
     def test_run_command_failure(self, mock_sys_exit, mock_subprocess_run):
         """
         Test that run_command exits on failure.
         """
         mock_subprocess_run.return_value.returncode = 1
         run_command(["invalid_command"])
-        mock_subprocess_run.assert_called_once_with(["invalid_command"], shell=False, cwd=None)
+        mock_subprocess_run.assert_called_once_with(
+            ["invalid_command"], shell=False, cwd=None
+        )
         mock_sys_exit.assert_called_once_with(1)
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_run_command_with_shell(self, mock_subprocess_run):
         """
         Test that run_command runs successfully with shell=True.
         """
         mock_subprocess_run.return_value.returncode = 0
         run_command(["echo Hello World"], shell=True)
-        mock_subprocess_run.assert_called_once_with(["echo Hello World"], shell=True, cwd=None)
+        mock_subprocess_run.assert_called_once_with(
+            ["echo Hello World"], shell=True, cwd=None
+        )
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_run_command_with_cwd(self, mock_subprocess_run):
         """
         Test that run_command runs successfully with a specific working directory.
         """
         mock_subprocess_run.return_value.returncode = 0
         run_command(["ls"], cwd="/home/user")
-        mock_subprocess_run.assert_called_once_with(["ls"], shell=False, cwd="/home/user")
+        mock_subprocess_run.assert_called_once_with(
+            ["ls"], shell=False, cwd="/home/user"
+        )
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_run_command_replace_python(self, mock_subprocess_run):
         """
         Test that run_command replaces 'python3.11' with the current Python executable.
         """
         mock_subprocess_run.return_value.returncode = 0
         run_command(["python3.11", "--version"])
-        mock_subprocess_run.assert_called_once_with([sys.executable, "--version"], shell=False, cwd=None)
+        mock_subprocess_run.assert_called_once_with(
+            [sys.executable, "--version"], shell=False, cwd=None
+        )
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_run_command_string_command(self, mock_subprocess_run):
         """
         Test run_command with a string command to ensure replacement of 'python3.11' with sys.executable.
         """
         mock_subprocess_run.return_value.returncode = 0
         run_command("python3.11 --version", shell=True)
-        mock_subprocess_run.assert_called_once_with(f"{sys.executable} --version", shell=True, cwd=None)
+        mock_subprocess_run.assert_called_once_with(
+            f"{sys.executable} --version", shell=True, cwd=None
+        )
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_run_command_string_command_no_replacement(self, mock_subprocess_run):
         """
         Test run_command with a string command that does not require replacement.
         """
         mock_subprocess_run.return_value.returncode = 0
         run_command("echo Hello World", shell=True)
-        mock_subprocess_run.assert_called_once_with("echo Hello World", shell=True, cwd=None)
+        mock_subprocess_run.assert_called_once_with(
+            "echo Hello World", shell=True, cwd=None
+        )

--- a/tests/test_app_common/test_base_lambda_handler.py
+++ b/tests/test_app_common/test_base_lambda_handler.py
@@ -1,13 +1,17 @@
-import pytest
-from unittest.mock import patch
 import traceback
+from unittest.mock import patch
+
+import pytest
+
 from app_common.base_lambda_handler import BaseLambdaHandler
+
 
 # Create a concrete subclass for testing purposes
 class TestLambdaHandler(BaseLambdaHandler):
     def _handle(self):
         # Simple implementation for testing
         return "Test handle executed"
+
 
 def test_test_lambda_handler_initialization():
     """
@@ -20,6 +24,7 @@ def test_test_lambda_handler_initialization():
     assert handler.body is None
     assert handler.headers is None
 
+
 def test_test_lambda_handler_on_error():
     """
     Test that the _on_error method correctly handles exceptions and prints the error and traceback.
@@ -27,18 +32,23 @@ def test_test_lambda_handler_on_error():
     handler = TestLambdaHandler()
     error_message = "Test Exception"
 
-    with patch('builtins.print') as mock_print:
+    with patch("builtins.print") as mock_print:
         try:
             raise Exception(error_message)
         except Exception as e:
-            traceback_info = traceback.format_exc()  # Capture the traceback within the except block
+            traceback_info = (
+                traceback.format_exc()
+            )  # Capture the traceback within the except block
             handler._on_error(e, traceback_info)
 
         # Check that the error message is printed
-        mock_print.assert_any_call(f"BaseLambdaHandler::OnError():: Error occurred:\n{error_message}")
-        
+        mock_print.assert_any_call(
+            f"BaseLambdaHandler::OnError():: Error occurred:\n{error_message}"
+        )
+
         # Check if the debug statements are showing correct values
         mock_print.assert_any_call(traceback_info)
+
 
 def test_test_lambda_handler_handle():
     """
@@ -47,4 +57,3 @@ def test_test_lambda_handler_handle():
     handler = TestLambdaHandler()
     result = handler._handle()
     assert result == "Test handle executed"
-


### PR DESCRIPTION
This PR does two things:
1. Completes the unit tests for `app_common/app_utils.py`
2. Add `black` and `isort` code formatters

Unit test coverage for for `app_common/app_utils.py` is now at 100%.