### PR TITLE
Fix install requirements logic

### DIFF
--- a/app_scripts/app_install_reqs.py
+++ b/app_scripts/app_install_reqs.py
@@ -123,21 +123,24 @@ def _install_requirements_recursively(do_log_func, run_cmd_func):
             # install the git repositories in the packages directory
             _install_from_aws_common(do_log_func, run_cmd_func, target=packages_dir)
 
-            if pip_requirements_file in files:
-                do_log_func(f"Installing {pip_requirements_path} (will be quiet)...")
-                # install the requirements in the packages directory
-                run_cmd_func(
-                    [
-                        "pip",
-                        "install",
-                        "-r",
-                        pip_requirements_path,
-                        "--target",
-                        packages_dir,
-                        "--upgrade",
-                        "--quiet",
-                    ]
-                )
+            for pip_requirements_file in pip_requirements_file_list:
+                if pip_requirements_file in files:
+                    do_log_func(
+                        f"Installing {pip_requirements_path} (will be quiet)..."
+                    )
+                    # install the requirements in the packages directory
+                    run_cmd_func(
+                        [
+                            "pip",
+                            "install",
+                            "-r",
+                            pip_requirements_path,
+                            "--target",
+                            packages_dir,
+                            "--upgrade",
+                            "--quiet",
+                        ]
+                    )
 
         # Special handling for AWS Lambda Layers
         if root.startswith(("layers", "./layers")):


### PR DESCRIPTION
We had a problem with the logic of the requirements installation, which didn't consider the requirements under the "lambdas" directory. Now, it's fixed.