### PR TITLE
chore-pypi: Enables publishing to PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ multi_line_output = 3  # Ensure similar line breaks for imports as Black
 include_trailing_comma = true  # Matches Black's default style
 
 [tool.poetry]
-name = "aws-common"
+name = "aws-commons"
 version = "0.1.0"
 description = "A shared package for common modules and constants for AWS Lambda applications"
 authors = ["LARS AI"]


### PR DESCRIPTION
Fix #26, enabling publishing to PyPI. The package name had to be renamed to `aws-commons` (plural), as there was already a aws-commons published in PyPI.