### PR TITLE
Issue 110 Add a helper method to create table resources in dynamodb_utils.py.

### DIFF
--- a/app_common/base_lambda_handler.py
+++ b/app_common/base_lambda_handler.py
@@ -702,8 +702,8 @@ class BaseLambdaHandler(ABC):
         """
         return app_utils.json_dumps(data, indent=indent, cls=cls)
 
-    def _get_path_parameter(self, name: str) -> str:
+    def _get_path_parameter(self, parameter_name: str) -> str:
         """
-        Extracts the path parameter from the event.
+        Extracts the path parameter with the given name from the event dictionary.
         """
-        return self.event["pathParameters"][name]
+        return self.event["pathParameters"][parameter_name]

--- a/app_common/test_utils.py
+++ b/app_common/test_utils.py
@@ -1,0 +1,34 @@
+"""
+This module contains utility functions meant to be used in tests.
+"""
+
+import os
+
+
+def set_aws_environment_variables(
+    aws_access_key_id: str,
+    aws_secret_access_key: str,
+    aws_security_token: str,
+    aws_session_token: str,
+    aws_default_region: str = "us-east-1",
+):
+    """
+    Sets some environment variables used by AWS.
+    """
+    os.environ["AWS_ACCESS_KEY_ID"] = aws_access_key_id
+    os.environ["AWS_SECRET_ACCESS_KEY"] = aws_secret_access_key
+    os.environ["AWS_SECURITY_TOKEN"] = aws_security_token
+    os.environ["AWS_SESSION_TOKEN"] = aws_session_token
+    os.environ["AWS_DEFAULT_REGION"] = aws_default_region
+
+
+def set_fake_aws_environment_variables(aws_default_region: str = "us-east-1"):
+    """
+    Sets some environment variables used by AWS with fake values.
+    This is meant to be used mainly for testing purposes, as some resources provided
+    by the ``boto3`` library refuse to initialize when certain environment variables
+    are empty.
+    """
+    set_aws_environment_variables(
+        "testing", "testing", "testing", "testing", aws_default_region
+    )


### PR DESCRIPTION
The proposed changes add the `create_table_resource()` method to `dynamodb_utils.py`, which will be useful for DynamoDB testing downstream.