### PR TITLE
Make `json_dumps` More Flexible by Allowing Additional `kwargs`

### DIFF
--- a/app_common/app_utils.py
+++ b/app_common/app_utils.py
@@ -74,11 +74,11 @@ def is_numeric(x) -> bool:
         return False
 
 
-def json_dumps(data, indent=4, cls=DecimalEncoder) -> str:
+def json_dumps(data, indent=4, cls=DecimalEncoder, **kwargs) -> str:
     """
     Utility method to serialize data to JSON, including Decimal values.
     """
-    return json.dumps(data, indent=indent, cls=cls)
+    return json.dumps(data, indent=indent, cls=cls, **kwargs)
 
 
 def _do_log(

--- a/app_common/base_lambda_handler.py
+++ b/app_common/base_lambda_handler.py
@@ -696,11 +696,11 @@ class BaseLambdaHandler(ABC):
         return boto3.client("ssm")
 
     @staticmethod
-    def json_dumps(data, indent=4, cls=app_utils.DecimalEncoder) -> str:
+    def json_dumps(data, indent=4, cls=app_utils.DecimalEncoder, **kwargs) -> str:
         """
         Utility method to serialize data to JSON, including Decimal values.
         """
-        return app_utils.json_dumps(data, indent=indent, cls=cls)
+        return app_utils.json_dumps(data, indent=indent, cls=cls, **kwargs)
 
     def _get_path_parameter(self, parameter_name: str) -> str:
         """

--- a/tests/unit/test_app_common/test_app_utils.py
+++ b/tests/unit/test_app_common/test_app_utils.py
@@ -13,6 +13,7 @@ from app_common.app_utils import (
     get_first_non_none,
     http_request,
     is_numeric,
+    json_dumps,
     run_command,
     str_is_none_or_empty,
 )
@@ -842,3 +843,30 @@ class TestRunCommand:
         mock_subprocess_run.assert_called_once_with(
             "echo Hello World", shell=True, cwd=None
         )
+
+
+class TestJsonDumps:
+    """
+    Test cases for the json_dumps function.
+
+    The json_dumps function is a wrapper around json.dumps that provides consistent
+    default parameters and handles encoding of special characters.
+    """
+
+    def test_json_dumps_ensure_ascii_false(self):
+        """
+        Test json_dumps with ensure_ascii set to False
+        """
+        data = {"key": "value", "unicode": "café"}
+        json_data = json_dumps(data, indent=None, ensure_ascii=False)
+        expected_json = '{"key": "value", "unicode": "café"}'
+        assert json_data == expected_json
+
+    def test_json_dumps_ensure_ascii_true(self):
+        """
+        Test json_dumps with ensure_ascii set to True
+        """
+        data = {"key": "value", "unicode": "café"}
+        json_data = json_dumps(data, indent=None)
+        expected_json = '{"key": "value", "unicode": "caf\\u00e9"}'
+        assert json_data == expected_json

--- a/tests/unit/test_app_common/test_base_lambda_handler.py
+++ b/tests/unit/test_app_common/test_base_lambda_handler.py
@@ -831,3 +831,30 @@ class TestBaseLambdaHandler:
         without a default value.
         """
         assert self.handler.get_env_var("NON_EXISTENT_VAR") is None
+
+
+class TestJsonDumpsInBaseLambdaHandler:
+    """
+    Test cases for the json_dumps function in BaseLambdaHandler.
+
+    The json_dumps function is a wrapper around json.dumps that provides consistent
+    default parameters and handles encoding of special characters.
+    """
+
+    def test_json_dumps_ensure_ascii_false(self):
+        """
+        Test json_dumps with ensure_ascii set to False
+        """
+        data = {"key": "value", "unicode": "café"}
+        json_data = BaseLambdaHandler.json_dumps(data, indent=None, ensure_ascii=False)
+        expected_json = '{"key": "value", "unicode": "café"}'
+        assert json_data == expected_json
+
+    def test_json_dumps_ensure_ascii_true(self):
+        """
+        Test json_dumps with ensure_ascii set to True
+        """
+        data = {"key": "value", "unicode": "café"}
+        json_data = BaseLambdaHandler.json_dumps(data, indent=None)
+        expected_json = '{"key": "value", "unicode": "caf\\u00e9"}'
+        assert json_data == expected_json


### PR DESCRIPTION
This PR enhances the `json_dumps` function by adding support for additional keyword arguments (`**kwargs`). This allows greater flexibility when serializing JSON, enabling users to pass custom options directly to `json.dumps`.

#### **Changes Introduced**
- Updated `json_dumps` function to accept `**kwargs`, passing them to `json.dumps`.
- Modified both `app_utils.json_dumps` and `BaseLambdaHandler.json_dumps` to include this enhancement.
- Updated related test cases in `test_app_utils.py` and `test_base_lambda_handler.py` to validate new functionality.
- Ensured backward compatibility by maintaining default parameter values.

#### **Motivation**
This change allows developers to specify options such as `ensure_ascii`, `sort_keys`, and others directly when calling `json_dumps`, making the function more flexible and adaptable to various use cases.

#### **Testing**
- Added unit tests to verify behavior with `ensure_ascii=True/False`.
- Ensured existing test cases pass successfully.

#### **Impact**
- **Backward Compatible:** Yes, default behavior remains unchanged.
- **Use Case:** Allows more control over JSON serialization, making it easier to integrate with external APIs or specific formatting needs.

Let me know if you’d like any refinements! 🚀